### PR TITLE
Implement model

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"find-webcams/models"
+
+	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/discovery"
+)
+
+func main() {
+	module.ModularMain(resource.APIModel{discovery.API, models.WebcamDiscovery})
+}

--- a/models/module.go
+++ b/models/module.go
@@ -29,7 +29,7 @@ func init() {
 	)
 }
 
-type findWebcamsWebcamDiscovery struct {
+type findCams struct {
 	resource.Named
 	resource.TriviallyCloseable
 	resource.AlwaysRebuild
@@ -38,7 +38,7 @@ type findWebcamsWebcamDiscovery struct {
 }
 
 func newFindWebcamsWebcamDiscovery(_ context.Context, _ resource.Dependencies, conf resource.Config, logger logging.Logger) (discovery.Service, error) {
-	s := &findWebcamsWebcamDiscovery{
+	s := &findCams{
 		Named:  conf.ResourceName().AsNamed(),
 		logger: logger,
 	}
@@ -46,7 +46,7 @@ func newFindWebcamsWebcamDiscovery(_ context.Context, _ resource.Dependencies, c
 }
 
 // DiscoverResources implements discovery.Service.
-func (s *findWebcamsWebcamDiscovery) DiscoverResources(ctx context.Context, extra map[string]any) ([]resource.Config, error) {
+func (s *findCams) DiscoverResources(ctx context.Context, extra map[string]any) ([]resource.Config, error) {
 	return findCameras(ctx, getVideoDrivers, s.logger)
 }
 

--- a/models/module.go
+++ b/models/module.go
@@ -1,0 +1,141 @@
+package models
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/pion/mediadevices/pkg/driver"
+	"github.com/pion/mediadevices/pkg/prop"
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/camera/videosource"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/discovery"
+	"go.viam.com/rdk/utils"
+)
+
+var (
+	WebcamDiscovery  = resource.NewModel("rand", "find-webcams", "webcam-discovery")
+	errUnimplemented = errors.New("unimplemented")
+)
+
+func init() {
+	resource.RegisterService(discovery.API, WebcamDiscovery,
+		resource.Registration[discovery.Service, *Config]{
+			Constructor: newFindWebcamsWebcamDiscovery,
+		},
+	)
+}
+
+type Config struct {
+	resource.TriviallyValidateConfig
+}
+
+type findWebcamsWebcamDiscovery struct {
+	resource.Named
+	resource.TriviallyCloseable
+	resource.AlwaysRebuild
+
+	logger logging.Logger
+	cfg    *Config
+}
+
+func newFindWebcamsWebcamDiscovery(ctx context.Context, deps resource.Dependencies, rawConf resource.Config, logger logging.Logger) (discovery.Service, error) {
+	conf, err := resource.NativeConfig[*Config](rawConf)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &findWebcamsWebcamDiscovery{
+		Named:  rawConf.ResourceName().AsNamed(),
+		logger: logger,
+		cfg:    conf,
+	}
+	return s, nil
+}
+
+// DiscoverResources implements discovery.Service.
+func (s *findWebcamsWebcamDiscovery) DiscoverResources(ctx context.Context, extra map[string]any) ([]resource.Config, error) {
+	return findCameras(ctx, getVideoDrivers, s.logger)
+}
+
+// getVideoDrivers is a helper callback passed to the registered Discover func to get all video drivers.
+func getVideoDrivers() []driver.Driver {
+	return driver.GetManager().Query(driver.FilterVideoRecorder())
+}
+
+// getProperties is a helper func for webcam discovery that returns the Media properties of a specific driver.
+// It is NOT related to the GetProperties camera proto API.
+func getProperties(d driver.Driver) (_ []prop.Media, err error) {
+	// Need to open driver to get properties
+	if d.Status() == driver.StateClosed {
+		errOpen := d.Open()
+		if errOpen != nil {
+			return nil, errOpen
+		}
+		defer func() {
+			if errClose := d.Close(); errClose != nil {
+				err = errClose
+			}
+		}()
+	}
+	return d.Properties(), err
+}
+
+// Discover webcam attributes.
+func findCameras(ctx context.Context, getDrivers func() []driver.Driver, logger logging.Logger) ([]resource.Config, error) {
+	driver.Initialize()
+	var webcams []resource.Config
+	drivers := getDrivers()
+	for _, d := range drivers {
+		driverInfo := d.Info()
+
+		props, err := getProperties(d)
+		if len(props) == 0 {
+			logger.CDebugw(ctx, "no properties detected for driver, skipping discovery...", "driver", driverInfo.Label)
+			continue
+		} else if err != nil {
+			logger.CDebugw(ctx, "cannot access driver properties, skipping discovery...", "driver", driverInfo.Label, "error", err)
+			continue
+		}
+
+		if d.Status() == driver.StateRunning {
+			logger.CDebugw(ctx, "driver is in use, skipping discovery...", "driver", driverInfo.Label)
+			continue
+		}
+
+		labelParts := strings.Split(driverInfo.Label, driver.LabelSeparator)
+		label := labelParts[0]
+
+		name, id := func() (string, string) {
+			nameParts := strings.Split(driverInfo.Name, driver.LabelSeparator)
+			if len(nameParts) > 1 {
+				return nameParts[0], nameParts[1]
+			}
+			// fallback to the label if the name does not have an any additional parts to use.
+			return nameParts[0], label
+		}()
+
+		for _, prop := range props {
+			attributes := videosource.WebcamConfig{
+				Path:      id,
+				Format:    string(prop.Video.FrameFormat),
+				Width:     prop.Video.Width,
+				Height:    prop.Video.Height,
+				FrameRate: prop.Video.FrameRate,
+			}
+
+			wc := resource.Config{
+				Name:                name,
+				API:                 camera.API,
+				Model:               videosource.ModelWebcam,
+				Attributes:          utils.AttributeMap{},
+				ConvertedAttributes: attributes,
+			}
+
+			webcams = append(webcams, wc)
+		}
+	}
+	return webcams, nil
+}

--- a/models/module.go
+++ b/models/module.go
@@ -98,7 +98,9 @@ func findCameras(ctx context.Context, getDrivers func() []driver.Driver, logger 
 		labelParts := strings.Split(driverInfo.Label, mdcam.LabelSeparator)
 		label := labelParts[0]
 
-		name, id := func() (string, string) {
+		// TODO: test with actual webcams to sanitize name so we can
+		// actually confiure the webcams
+		_, id := func() (string, string) {
 			nameParts := strings.Split(driverInfo.Name, mdcam.LabelSeparator)
 			if len(nameParts) > 1 {
 				return nameParts[0], nameParts[1]
@@ -130,7 +132,7 @@ func findCameras(ctx context.Context, getDrivers func() []driver.Driver, logger 
 			}
 
 			wc := resource.Config{
-				Name:                name,
+				Name:                id,
 				API:                 camera.API,
 				Model:               videosource.ModelWebcam,
 				Attributes:          result,

--- a/models/module_test.go
+++ b/models/module_test.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/test"
+
+	"github.com/pion/mediadevices/pkg/driver"
+	"github.com/pion/mediadevices/pkg/prop"
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/camera/videosource"
+)
+
+// fakeDriver is a driver has a label and media properties.
+type fakeDriver struct {
+	label string
+	props []prop.Media
+}
+
+func (d *fakeDriver) Open() error              { return nil }
+func (d *fakeDriver) Properties() []prop.Media { return d.props }
+func (d *fakeDriver) ID() string               { return d.label }
+func (d *fakeDriver) Info() driver.Info        { return driver.Info{Label: d.label} }
+func (d *fakeDriver) Status() driver.State     { return "some state" }
+func (d *fakeDriver) Close() error             { return nil }
+
+func newFakeDriver(label string, props []prop.Media) driver.Driver {
+	return &fakeDriver{label: label, props: props}
+}
+
+func testGetDrivers() []driver.Driver {
+	props := prop.Media{
+		Video: prop.Video{Width: 320, Height: 240, FrameFormat: "some format", FrameRate: 30.0},
+	}
+	withProps := newFakeDriver("some_label", []prop.Media{props})
+	withoutProps := newFakeDriver("another label", []prop.Media{})
+	return []driver.Driver{withProps, withoutProps}
+}
+
+func TestDiscoveryWebcam(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	resp, err := findCameras(context.Background(), testGetDrivers, logger)
+
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp, test.ShouldHaveLength, 1)
+	test.That(t, resp[0].API, test.ShouldResemble, camera.API)
+	test.That(t, resp[0].Name, test.ShouldResemble, "some_label")
+
+	cfg, ok := resp[0].ConvertedAttributes.(videosource.WebcamConfig)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	test.That(t, cfg, test.ShouldHaveSameTypeAs, videosource.WebcamConfig{})
+
+	test.That(t, cfg.Width, test.ShouldEqual, 320)
+	test.That(t, cfg.Height, test.ShouldEqual, 240)
+	test.That(t, cfg.Format, test.ShouldResemble, "some format")
+	test.That(t, cfg.FrameRate, test.ShouldEqual, 30.)
+}


### PR DESCRIPTION
This implements a discovery service within this module to find webcams connected to your device.

It's still untested. We're mostly porting over code from rdk so we have something to work with when the DiscoverComponents API is removed.

I will upload it as an unofficial module to my namespace.

Original code is here: https://github.com/viamrobotics/rdk/blob/8f0be07b7661394ed84f03519825c790813421fe/components/camera/videosource/webcam.go#L64